### PR TITLE
Add rotation inputs to Orbitals containers

### DIFF
--- a/NINA.Joko.Plugin.Orbitals/SequenceItems/DataTemplates.xaml
+++ b/NINA.Joko.Plugin.Orbitals/SequenceItems/DataTemplates.xaml
@@ -123,7 +123,7 @@
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Foreground="{StaticResource ButtonForegroundBrush}"
-                                            Text="{Binding Target.Rotation}" />
+                                            Text="{Binding Target.PositionAngle}" />
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Foreground="{StaticResource ButtonForegroundBrush}"
@@ -150,6 +150,7 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
@@ -253,6 +254,32 @@
                                     VerticalAlignment="Center">
                                     <Run Text="{Binding Distance.DisplayDistance, StringFormat=\{0:0.####\}, Mode=OneWay}" /> <Run Text="{Binding Distance.DisplayUnits, Mode=OneWay}" />
                                 </TextBlock>
+                                <TextBlock
+                                    Grid.Row="6"
+                                    Grid.Column="0"
+                                    Margin="5"
+                                    VerticalAlignment="Center"
+                                    Text="{ns:Loc LblRotation}" />
+                                <ninactrl:UnitTextBox
+                                    Grid.Row="6"
+                                    Grid.Column="1"
+                                    Margin="5"
+                                    Width="40"
+                                    VerticalAlignment="Center"
+                                    HorizontalAlignment="Left"
+                                    Unit="°">
+                                    <ninactrl:UnitTextBox.Text>
+                                        <Binding Path="Target.PositionAngle" UpdateSourceTrigger="LostFocus">
+                                            <Binding.ValidationRules>
+                                                <rules:DoubleRangeRule>
+                                                    <rules:DoubleRangeRule.ValidRange>
+                                                        <rules:DoubleRangeChecker Maximum="360" Minimum="0" />
+                                                    </rules:DoubleRangeRule.ValidRange>
+                                                </rules:DoubleRangeRule>
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </ninactrl:UnitTextBox.Text>
+                                </ninactrl:UnitTextBox>
                                 <alt:AltitudeChart
                                     Grid.Row="0"
                                     Grid.RowSpan="6"
@@ -462,7 +489,7 @@
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Foreground="{StaticResource ButtonForegroundBrush}"
-                                            Text="{Binding Target.Rotation}" />
+                                            Text="{Binding Target.PositionAngle}" />
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Foreground="{StaticResource ButtonForegroundBrush}"
@@ -489,6 +516,7 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
@@ -579,6 +607,32 @@
                                     VerticalAlignment="Center">
                                     <Run Text="{Binding Distance.DisplayDistance, StringFormat=\{0:0.####\}, Mode=OneWay}" /> <Run Text="{Binding Distance.DisplayUnits, Mode=OneWay}" />
                                 </TextBlock>
+                                <TextBlock
+                                    Grid.Row="6"
+                                    Grid.Column="0"
+                                    Margin="5"
+                                    VerticalAlignment="Center"
+                                    Text="{ns:Loc LblRotation}" />
+                                <ninactrl:UnitTextBox
+                                    Grid.Row="6"
+                                    Grid.Column="1"
+                                    Margin="5"
+                                    Width="40"
+                                    VerticalAlignment="Center"
+                                    HorizontalAlignment="Left"
+                                    Unit="°">
+                                    <ninactrl:UnitTextBox.Text>
+                                        <Binding Path="Target.PositionAngle" UpdateSourceTrigger="LostFocus">
+                                            <Binding.ValidationRules>
+                                                <rules:DoubleRangeRule>
+                                                    <rules:DoubleRangeRule.ValidRange>
+                                                        <rules:DoubleRangeChecker Maximum="360" Minimum="0" />
+                                                    </rules:DoubleRangeRule.ValidRange>
+                                                </rules:DoubleRangeRule>
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </ninactrl:UnitTextBox.Text>
+                                </ninactrl:UnitTextBox>
                                 <alt:AltitudeChart
                                     Grid.Row="0"
                                     Grid.RowSpan="6"
@@ -788,7 +842,7 @@
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Foreground="{StaticResource ButtonForegroundBrush}"
-                                            Text="{Binding Target.Rotation}" />
+                                            Text="{Binding Target.PositionAngle}" />
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Foreground="{StaticResource ButtonForegroundBrush}"
@@ -815,6 +869,7 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
@@ -912,6 +967,32 @@
                                         VerticalAlignment="Center"
                                         Text="JWST data is out of date" />
                                 </StackPanel>
+                                <TextBlock
+                                    Grid.Row="7"
+                                    Grid.Column="0"
+                                    Margin="5"
+                                    VerticalAlignment="Center"
+                                    Text="{ns:Loc LblRotation}" />
+                                <ninactrl:UnitTextBox
+                                    Grid.Row="7"
+                                    Grid.Column="1"
+                                    Margin="5"
+                                    Width="40"
+                                    VerticalAlignment="Center"
+                                    HorizontalAlignment="Left"
+                                    Unit="°">
+                                    <ninactrl:UnitTextBox.Text>
+                                        <Binding Path="Target.PositionAngle" UpdateSourceTrigger="LostFocus">
+                                            <Binding.ValidationRules>
+                                                <rules:DoubleRangeRule>
+                                                    <rules:DoubleRangeRule.ValidRange>
+                                                        <rules:DoubleRangeChecker Maximum="360" Minimum="0" />
+                                                    </rules:DoubleRangeRule.ValidRange>
+                                                </rules:DoubleRangeRule>
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </ninactrl:UnitTextBox.Text>
+                                </ninactrl:UnitTextBox>
                                 <alt:AltitudeChart
                                     Grid.Row="0"
                                     Grid.RowSpan="7"
@@ -1121,7 +1202,7 @@
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Foreground="{StaticResource ButtonForegroundBrush}"
-                                            Text="{Binding Target.Rotation}" />
+                                            Text="{Binding Target.PositionAngle}" />
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Foreground="{StaticResource ButtonForegroundBrush}"
@@ -1150,6 +1231,7 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
@@ -1286,6 +1368,32 @@
                                     HorizontalAlignment="Left"
                                     IsEnabled="False"
                                     IsChecked="{Binding TrackingEnabled, Mode=OneWay}" />
+                                <TextBlock
+                                    Grid.Row="7"
+                                    Grid.Column="0"
+                                    Margin="5"
+                                    VerticalAlignment="Center"
+                                    Text="{ns:Loc LblRotation}" />
+                                <ninactrl:UnitTextBox
+                                    Grid.Row="7"
+                                    Grid.Column="1"
+                                    Margin="5"
+                                    Width="40"
+                                    VerticalAlignment="Center"
+                                    HorizontalAlignment="Left"
+                                    Unit="°">
+                                    <ninactrl:UnitTextBox.Text>
+                                        <Binding Path="Target.PositionAngle" UpdateSourceTrigger="LostFocus">
+                                            <Binding.ValidationRules>
+                                                <rules:DoubleRangeRule>
+                                                    <rules:DoubleRangeRule.ValidRange>
+                                                        <rules:DoubleRangeChecker Maximum="360" Minimum="0" />
+                                                    </rules:DoubleRangeRule.ValidRange>
+                                                </rules:DoubleRangeRule>
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </ninactrl:UnitTextBox.Text>
+                                </ninactrl:UnitTextBox>
                                 <alt:AltitudeChart
                                     Grid.Row="0"
                                     Grid.RowSpan="7"

--- a/NINA.Joko.Plugin.Orbitals/SequenceItems/DataTemplates.xaml
+++ b/NINA.Joko.Plugin.Orbitals/SequenceItems/DataTemplates.xaml
@@ -196,7 +196,7 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="RA" />
+                                    Text="{ns:Loc LblRA}" />
                                 <TextBlock
                                     Grid.Row="1"
                                     Grid.Column="1"
@@ -208,7 +208,7 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Dec" />
+                                    Text="{ns:Loc LblDec}" />
                                 <TextBlock
                                     Grid.Row="2"
                                     Grid.Column="1"
@@ -549,7 +549,7 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="RA" />
+                                    Text="{ns:Loc LblRA}" />
                                 <TextBlock
                                     Grid.Row="1"
                                     Grid.Column="1"
@@ -561,7 +561,7 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Dec" />
+                                    Text="{ns:Loc LblDec}" />
                                 <TextBlock
                                     Grid.Row="2"
                                     Grid.Column="1"
@@ -883,7 +883,7 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="RA" />
+                                    Text="{ns:Loc LblRA}" />
                                 <TextBlock
                                     Grid.Row="1"
                                     Grid.Column="1"
@@ -895,7 +895,7 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Dec" />
+                                    Text="{ns:Loc LblDec}" />
                                 <TextBlock
                                     Grid.Row="2"
                                     Grid.Column="1"
@@ -1271,7 +1271,7 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="RA" />
+                                    Text="{ns:Loc LblRA}" />
                                 <TextBlock
                                     Grid.Row="1"
                                     Grid.Column="1"
@@ -1295,7 +1295,7 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Dec" />
+                                    Text="{ns:Loc LblDec}" />
                                 <TextBlock
                                     Grid.Row="2"
                                     Grid.Column="1"


### PR DESCRIPTION
Wanted a certain position angle when framing a comet, so added textboxes to allow for programming the `Target.PositionAngle` property defined in `InputTarget`. This enables use of instructions such as Slew Center Rotate where "Rotate" can now be something other than 0 degrees.

Also converted "RA" and "Dec" text to their label equivalents along the way.