### PR TITLE
Scope build-and-release trigger to v3.3.x on develop

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,7 +3,12 @@ name: Build and Release
 on:
   push:
     tags:
-      - 'release/v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      # develop = NINA 3.3 line. Scope the trigger so a stray
+      # release/v3.1.* or release/v3.2.* tag pushed on develop's lineage
+      # can't fire this workflow and publish a 3.1.x/3.2.x-versioned
+      # manifest into o/Orbitals/3.3.0. The release/3.2 branch has its
+      # own workflow scoped to release/v3.1.* / release/v3.2.*.
+      - 'release/v3.3.[0-9]+.[0-9]+'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Restrict the `build-and-release.yml` tag trigger on `develop` so it only fires for `release/v3.3.x.x` tags. The previous generic pattern `'release/v[0-9]+.[0-9]+.[0-9]+.[0-9]+'` would match any `release/v*` tag — including a stray `release/v3.1.0.x` or `release/v3.2.0.x` tag pushed on develop's lineage by mistake. Such a tag would run develop's workflow and publish a 3.1.x/3.2.x-versioned manifest into `o/Orbitals/3.3.0`, which is wrong.

Symmetric change: `release/3.2` already restricts its workflow to `release/v3.1.*` / `release/v3.2.*` (see PR #14). Each branch's workflow now only fires for the plugin major it actually ships.

### Diff

```yaml
on:
  push:
    tags:
-      - 'release/v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'release/v3.3.[0-9]+.[0-9]+'
```

(with an inline comment in the file explaining the scope.)

## Test plan

- [ ] Push a `release/v3.3.0.x` tag (real release) — workflow still fires.
- [ ] Push a hypothetical `release/v3.1.0.99` tag on a develop-lineage commit — workflow should NOT fire (verify in Actions tab).
- [ ] If plugin major ever bumps past 3.3 on this branch, update the pattern in the same commit that bumps the AssemblyVersion.