### PR TITLE
Port code-review fixes from the release/3.2 backport PR

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Build .NET Assemblies
         run: |
           dotnet restore "NINA.Joko.Plugin.Orbitals/NINA.Joko.Plugin.Orbitals.csproj"
-          dotnet build "NINA.Joko.Plugin.Orbitals/NINA.Joko.Plugin.Orbitals.csproj" -c Release -p:Platform=AnyCPU -p:PostBuildEvent= -p:Version=${{ env.VERSION }}
+          # AssemblyInfo.cs is the source of truth for AssemblyVersion (GenerateAssemblyInfo=false
+          # in the csproj), so don't pass -p:Version — it would be silently ignored and could
+          # mislead future maintainers into thinking the tag controls the embedded version.
+          dotnet build "NINA.Joko.Plugin.Orbitals/NINA.Joko.Plugin.Orbitals.csproj" -c Release -p:Platform=AnyCPU -p:PostBuildEvent=
 
       - name: Prepare package
         run: |

--- a/NINA.Joko.Plugin.Orbitals.Tests/ValidationRules/PositiveIntegerOrInfiniteRuleTests.cs
+++ b/NINA.Joko.Plugin.Orbitals.Tests/ValidationRules/PositiveIntegerOrInfiniteRuleTests.cs
@@ -13,7 +13,7 @@ namespace NINA.Joko.Plugin.Orbitals.Tests.ValidationRules {
         [TestCase("unlimited", true)]
         [TestCase("1", true)]
         [TestCase("100", true)]
-        [TestCase("0", false)]
+        [TestCase("0", true)]
         [TestCase("-1", false)]
         [TestCase("-100", false)]
         [TestCase("abc", false)]

--- a/NINA.Joko.Plugin.Orbitals.Tests/ValidationRules/PositiveIntegerRuleTests.cs
+++ b/NINA.Joko.Plugin.Orbitals.Tests/ValidationRules/PositiveIntegerRuleTests.cs
@@ -12,7 +12,7 @@ namespace NINA.Joko.Plugin.Orbitals.Tests.ValidationRules {
 
         [TestCase("1", true)]
         [TestCase("100", true)]
-        [TestCase("0", false)]
+        [TestCase("0", true)]
         [TestCase("-1", false)]
         [TestCase("-100", false)]
         [TestCase("abc", false)]

--- a/NINA.Joko.Plugin.Orbitals/Calculations/PVTableObject.cs
+++ b/NINA.Joko.Plugin.Orbitals/Calculations/PVTableObject.cs
@@ -50,7 +50,7 @@ namespace NINA.Joko.Plugin.Orbitals.Calculations {
 
         public PVTableObject Clone() {
             var cloned = new PVTableObject(orbitalElementsAccessor, this.Name, customHorizon, profileService);
-            cloned.SetDateAndPosition(cloned._referenceDate, cloned._latitude, cloned._longitude);
+            cloned.SetDateAndPosition(this._referenceDate, this._latitude, this._longitude);
             return cloned;
         }
     }

--- a/NINA.Joko.Plugin.Orbitals/Calculations/SolarSystemBodyObject.cs
+++ b/NINA.Joko.Plugin.Orbitals/Calculations/SolarSystemBodyObject.cs
@@ -51,7 +51,7 @@ namespace NINA.Joko.Plugin.Orbitals.Calculations {
 
         public SolarSystemBodyObject Clone() {
             var cloned = new SolarSystemBodyObject(orbitalElementsAccessor, SolarSystemBody, customHorizon);
-            cloned.SetDateAndPosition(cloned._referenceDate, cloned._latitude, cloned._longitude);
+            cloned.SetDateAndPosition(this._referenceDate, this._latitude, this._longitude);
             return cloned;
         }
     }

--- a/NINA.Joko.Plugin.Orbitals/Calculations/TLEObject.cs
+++ b/NINA.Joko.Plugin.Orbitals/Calculations/TLEObject.cs
@@ -107,7 +107,7 @@ namespace NINA.Joko.Plugin.Orbitals.Calculations {
 
         public TLEObject Clone() {
             var cloned = new TLEObject(satellite.Tle, customHorizon, profileService, epoch, rateDriftDelta);
-            cloned.SetDateAndPosition(cloned._referenceDate, cloned._latitude, cloned._longitude);
+            cloned.SetDateAndPosition(this._referenceDate, this._latitude, this._longitude);
             return cloned;
         }
     }

--- a/NINA.Joko.Plugin.Orbitals/SequenceItems/JWSTContainer.cs
+++ b/NINA.Joko.Plugin.Orbitals/SequenceItems/JWSTContainer.cs
@@ -89,6 +89,8 @@ namespace NINA.Joko.Plugin.Orbitals.SequenceItems {
             };
 
             clone.Target.PositionAngle = this.Target.PositionAngle;
+            clone.Target.InputCoordinates = this.Target.InputCoordinates.Clone();
+            clone.Target.DeepSkyObject = (this.Target.DeepSkyObject as PVTableObject).Clone();
 
             foreach (var item in clone.Items) {
                 item.AttachNewParent(clone);

--- a/NINA.Joko.Plugin.Orbitals/SequenceItems/ManualTLEContainer.cs
+++ b/NINA.Joko.Plugin.Orbitals/SequenceItems/ManualTLEContainer.cs
@@ -137,8 +137,9 @@ namespace NINA.Joko.Plugin.Orbitals.SequenceItems {
                 Conditions = new ObservableCollection<ISequenceCondition>(Conditions.Select(t => t.Clone() as ISequenceCondition))
             };
 
-            clone.TargetObject.Tle = TargetObject.Tle;
             clone.Target.PositionAngle = this.Target.PositionAngle;
+            clone.Target.InputCoordinates = this.Target.InputCoordinates.Clone();
+            clone.Target.DeepSkyObject = (this.Target.DeepSkyObject as TLEObject).Clone();
 
             foreach (var item in clone.Items) {
                 item.AttachNewParent(clone);

--- a/NINA.Joko.Plugin.Orbitals/SequenceItems/SolarSystemBodyContainer.cs
+++ b/NINA.Joko.Plugin.Orbitals/SequenceItems/SolarSystemBodyContainer.cs
@@ -89,8 +89,9 @@ namespace NINA.Joko.Plugin.Orbitals.SequenceItems {
                 Conditions = new ObservableCollection<ISequenceCondition>(Conditions.Select(t => t.Clone() as ISequenceCondition))
             };
 
-            clone.TargetObject.SolarSystemBody = TargetObject.SolarSystemBody;
             clone.Target.PositionAngle = this.Target.PositionAngle;
+            clone.Target.InputCoordinates = this.Target.InputCoordinates.Clone();
+            clone.Target.DeepSkyObject = (this.Target.DeepSkyObject as SolarSystemBodyObject).Clone();
 
             foreach (var item in clone.Items) {
                 item.AttachNewParent(clone);

--- a/NINA.Joko.Plugin.Orbitals/ValidationRules/PositiveIntegerOrInfiniteRule.cs
+++ b/NINA.Joko.Plugin.Orbitals/ValidationRules/PositiveIntegerOrInfiniteRule.cs
@@ -25,10 +25,10 @@ namespace NINA.Joko.Plugin.Orbitals.ValidationRules {
             if (s == "unlimited") {
                 return new ValidationResult(true, null);
             }
-            if (int.TryParse(s, NumberStyles.Number, cultureInfo, out var intval) && intval > 0) {
+            if (int.TryParse(s, NumberStyles.Number, cultureInfo, out var intval) && intval >= 0) {
                 return new ValidationResult(true, null);
             } else {
-                return new ValidationResult(false, "Value must be a positive integer or unlimited");
+                return new ValidationResult(false, "Value must be a non-negative integer or unlimited");
             }
         }
     }

--- a/NINA.Joko.Plugin.Orbitals/ValidationRules/PositiveIntegerRule.cs
+++ b/NINA.Joko.Plugin.Orbitals/ValidationRules/PositiveIntegerRule.cs
@@ -22,10 +22,10 @@ namespace NINA.Joko.Plugin.Orbitals.ValidationRules {
                 return new ValidationResult(false, "Null value");
             }
             var s = value.ToString();
-            if (int.TryParse(s, NumberStyles.Number, cultureInfo, out var intval) && intval > 0) {
+            if (int.TryParse(s, NumberStyles.Number, cultureInfo, out var intval) && intval >= 0) {
                 return new ValidationResult(true, null);
             } else {
-                return new ValidationResult(false, "Value must be a positive integer");
+                return new ValidationResult(false, "Value must be a non-negative integer");
             }
         }
     }


### PR DESCRIPTION
## Summary

Brings three of the four fixes from PR #14 (the release/3.2 backport) onto develop. They apply equally to this branch; the fourth (tests.yml wildcard for backport branches) is release/3.2-specific and stays only on PR #14.

### Changes

1. **`build-and-release.yml`** — drop `-p:Version=\${{ env.VERSION }}` from the build step. `<GenerateAssemblyInfo>false</GenerateAssemblyInfo>` in the csproj combined with hard-coded `AssemblyVersion` / `AssemblyFileVersion` in `AssemblyInfo.cs` means `-p:Version` was silently ignored. The hazard: a release tag whose version disagrees with the committed AssemblyInfo.cs would publish a ZIP whose embedded DLL version doesn't match the tag/manifest. `AssemblyInfo.cs` is now unambiguously the source of truth — bump there to release.

2. **`PositiveIntegerRule` / `PositiveIntegerOrInfiniteRule`** — relax `intval > 0` to `intval >= 0`. The original rule accepted any integer (so saved `0` values for `OrbitalPositionRefreshTime_sec`, `TLEPositionRefreshTime_sec`, `TLETrackStartWaitTime_sec` were valid). Tightening to strictly positive — which landed earlier on this branch — would show a red validation adorner on load for any user who had stored `0`. Now `0` is explicitly allowed; only negatives and non-integers are rejected. Test cases for `"0"` flipped to expect `true`; error messages updated to "non-negative integer".

3. **Sibling DSO + container `Clone` bugs.**
   - `PVTableObject.Clone`, `SolarSystemBodyObject.Clone`, `TLEObject.Clone` now pass `this._referenceDate / this._latitude / this._longitude` to `SetDateAndPosition` instead of the freshly-constructed clone's defaults (was a self-copy no-op). Brings them in line with `OrbitalElementsObject.Clone`.
   - `JWSTContainer.Clone`, `SolarSystemBodyContainer.Clone`, `ManualTLEContainer.Clone` now clone `Target.InputCoordinates` and replace `Target.DeepSkyObject` with the cloned DSO, so duplicated sequence items preserve reference date / lat / long / coordinates instead of resetting to "now" + current profile. Mirrors the fix release/3.2's commit \`7eb4faa\` applied to `OrbitalObjectContainer`. The pre-existing `clone.TargetObject.SolarSystemBody = …` and `clone.TargetObject.Tle = …` lines were removed (now redundant — those values flow through the DSO `Clone()` constructor; otherwise they'd be dead writes to a DSO replaced one line later).

## Test plan

- [x] `dotnet build NINA.Joko.Plugin.Orbitals.sln -c Debug` — **0 errors**
- [x] `dotnet test NINA.Joko.Plugin.Orbitals.Tests` — **223/223 passing**
- [ ] Manual smoke: duplicate a JWST / SolarSystemBody / ManualTLE sequence container in the advanced sequencer; verify the clone preserves the source's reference date and coordinates rather than resetting.
- [ ] Try saving an OrbitalPositionRefreshTime_sec of 0 in the options panel and confirm it no longer shows a red validation adorner.

## Related

- PR #14 — the release/3.2 backport where these fixes originated.
- PR #15 — the symmetric trigger-scoping change on develop (independent area of `build-and-release.yml`; should merge cleanly with this PR in either order).