### PR TITLE
CI: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version from tag
         run: |
@@ -60,7 +60,7 @@ jobs:
           Rename-Item -Path "manifest.json" -NewName "${{ env.PLUGIN_DLL_NAME }}.${{ env.VERSION }}.manifest.json"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -73,7 +73,7 @@ jobs:
             ./${{ env.PLUGIN_DLL_NAME }}.${{ env.VERSION }}.manifest.json
 
       - name: Upload manifest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plugin-manifest
           path: ${{ env.PLUGIN_DLL_NAME }}.${{ env.VERSION }}.manifest.json
@@ -103,7 +103,7 @@ jobs:
     if: needs.check-repo-exists.outputs.exists == 'true'
     steps:
       - name: Download manifest artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: plugin-manifest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -41,14 +41,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: TestResults/*.trx
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: TestResults/**/coverage.cobertura.xml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload HTML coverage summary
         if: always() && hashFiles('CoverageReport/summary.html') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-html
           path: CoverageReport/
@@ -122,7 +122,7 @@ jobs:
 
       - name: Post or update PR comment
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Clears the Node.js 20 deprecation warnings seen on the recent release runs by moving every action to its Node 24 runtime.

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-dotnet | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/github-script | v7 | v9 |
| softprops/action-gh-release | v2 | v3 |

## Compatibility notes
- All bumps require Actions Runner **≥ v2.327.1** — GitHub-hosted runners far exceed this.
- `upload-artifact`/`download-artifact` v5 breaking change only affects downloads **by ID**; we download by `name`, unaffected. The default zipped artifact + by-name download remain compatible.
- `github-script@v9` removes `require('@actions/github')` and injects `getOctokit`. The PR-comment script only `require('fs')` (Node builtin) and uses the injected `github`/`context` with stable `rest.issues.*` APIs — unaffected.
- `action-gh-release@v3` is a pure runtime move; `tag_name`/`name`/`draft`/`prerelease`/`files` inputs unchanged.

## Validation
The `tests.yml` workflow on this PR exercises `checkout@v6`, `setup-dotnet@v5`, `upload-artifact@v7`, and `github-script@v9` directly. The `build-and-release.yml` bumps (`gh-release@v3`, `download-artifact@v8`, `upload-artifact@v7`) only run on a release tag and will first be exercised on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)